### PR TITLE
Added Standard tier as supported for B2C

### DIFF
--- a/articles/api-management/api-management-howto-aad-b2c.md
+++ b/articles/api-management/api-management-howto-aad-b2c.md
@@ -17,7 +17,7 @@ ms.author: apimpm
 ---
 
 > [!WARNING]
-> Azure Active Directory B2C integration is available in the [Developer and Premium](https://azure.microsoft.com/en-us/pricing/details/api-management/) tiers only.
+> Azure Active Directory B2C integration is available in the [Developer, Standard and Premium](https://azure.microsoft.com/en-us/pricing/details/api-management/) tiers only.
 
 # How to authorize developer accounts by using Azure Active Directory B2C in Azure API Management
 ## Overview


### PR DESCRIPTION
According to the announcement from December, B2C integration with API Management is now available in the Standard tier as well: 
https://blogs.msdn.microsoft.com/apimanagement/2017/12/01/updates-to-azure-api-management-pricing/